### PR TITLE
feat: Add initial Windows support

### DIFF
--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -93,6 +93,18 @@ jobs:
             # fine depending on it.
             static: false
 
+          - name: windows-x86_64
+            runner: windows-latest
+            static: false
+            install-deps: |
+              Invoke-WebRequest -Uri 'https://downloads.sourceforge.net/project/gnuwin32/zlib/1.2.3/zlib-1.2.3-bin.zip' -OutFile 'zlib-bin.zip'
+              Invoke-WebRequest -Uri 'https://downloads.sourceforge.net/project/gnuwin32/zlib/1.2.3/zlib-1.2.3-lib.zip' -OutFile 'zlib-lib.zip'
+              Expand-Archive -Path 'zlib-bin.zip' -DestinationPath 'zlib'
+              Expand-Archive -Path 'zlib-lib.zip' -DestinationPath 'zlib'
+              echo "CPATH=$((Get-Item -Path 'zlib/include').FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+              echo "LIBRARY_PATH=$((Get-Item -Path 'zlib/lib').FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+              echo "$((Get-Item -Path 'zlib/bin').FullName)" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
           - name: macos-aarch64
             runner: macos-latest # Latest macOS images are already Apple Silicon-based
             static: false # Check the comment above for why we can't statically link on macOS
@@ -112,6 +124,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
+        if: matrix.env.install-deps
+        shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
         run: ${{ matrix.env.install-deps }}
 
       - uses: ./.github/actions/setup-haskell
@@ -124,7 +138,8 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
-      - name: Build and package
+      - name: Build and package (Unix)
+        if: runner.os != 'Windows'
         working-directory: waspc
         env:
           LC_ALL: C.UTF-8 # In some Docker containers the LOCALE is not UTF-8 by default
@@ -132,6 +147,15 @@ jobs:
           ./run build:all${{ matrix.env.static && ':static' || '' }}
           mkdir -p artifacts
           ./tools/make_binary_package.sh "artifacts/wasp-${{ matrix.env.name }}.tar.gz"
+
+      - name: Build and package (Windows)
+        if: runner.os == 'Windows'
+        working-directory: waspc
+        shell: bash
+        run: |
+          ./run build:all${{ matrix.env.static && ':static' || '' }}
+          mkdir -p artifacts
+          powershell -File ./tools/make_binary_package.ps1 "artifacts/wasp-${{ matrix.env.name }}.zip"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/installer.ps1
+++ b/installer.ps1
@@ -1,0 +1,141 @@
+[CmdletBinding()]
+param (
+    [string]$Version,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+$HomeLocalBin = "$env:LOCALAPPDATA\bin"
+$HomeLocalShare = "$env:LOCALAPPDATA"
+
+$Red = "`e[31m"
+$Green = "`e[32m"
+$Bold = "`e[1m"
+$Reset = "`e[0m"
+
+function Main {
+    # Send telemetry in the background.
+    Start-Job -ScriptBlock {
+        param($PostHogApiKey, $OsInfo)
+
+        $Data = @{
+            api_key = $PostHogApiKey
+            type = "capture"
+            event = "install-script:run"
+            distinct_id = (Get-Random).ToString() + $([DateTimeOffset]::UtcNow.ToUnixTimeSeconds().ToString())
+            properties = @{
+                os = $OsInfo
+                context = if ($env:CI) { "CI" } else { "" }
+            }
+        } | ConvertTo-Json
+
+        Invoke-RestMethod -Uri "https://app.posthog.com/capture" -Method Post -Body $Data -ContentType "application/json"
+    } -ArgumentList "CdDd2A0jKTI2vFAsrI9JWm3MqpOcgHz1bMyogAcwsE4", "windows" | Out-Null
+
+    Install-Based-On-Arch
+}
+
+function Install-Based-On-Arch {
+    # For now, we only support x86_64.
+    if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") {
+        Install-From-Bin-Package "wasp-windows-x86_64.zip"
+    } else {
+        Write-Error "Sorry, this installer does not support your architecture: $env:PROCESSOR_ARCHITECTURE"
+        exit 1
+    }
+}
+
+function Get-Latest-Wasp-Version {
+    $Uri = "https://github.com/wasp-lang/wasp/releases/latest"
+    $Response = Invoke-WebRequest -Uri $Uri -MaximumRedirection 0 -ErrorAction SilentlyContinue
+    if ($Response.StatusCode -eq 302) {
+        return $Response.Headers.Location.Split('/')[-1].TrimStart('v')
+    } else {
+        Write-Error "Failed to get the latest Wasp version."
+        exit 1
+    }
+}
+
+function Install-From-Bin-Package {
+    param (
+        [string]$BinPackageName
+    )
+
+    $LatestVersion = Get-Latest-Wasp-Version
+
+    if ([string]::IsNullOrEmpty($Version)) {
+        $VersionToInstall = $LatestVersion
+    } else {
+        $VersionToInstall = $Version
+    }
+
+    if ($VersionToInstall -eq $LatestVersion) {
+        $LatestVersionMessage = "latest"
+    } else {
+        $LatestVersionMessage = "latest is $LatestVersion"
+    }
+
+    Write-Host "Installing wasp version $VersionToInstall ($LatestVersionMessage)."
+
+    $DataDstDir = "$HomeLocalShare\wasp-lang\$VersionToInstall"
+    New-Item -ItemType Directory -Force -Path $DataDstDir | Out-Null
+
+    if (-not (Get-ChildItem -Path $DataDstDir)) {
+        $PackageUrl = "https://github.com/wasp-lang/wasp/releases/download/v$VersionToInstall/$BinPackageName"
+        $TempDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "wasp-installer")
+        $PackagePath = Join-Path $TempDir $BinPackageName
+
+        Write-Host "Downloading binary package to temporary dir and unpacking it there..."
+        if ($DryRun) {
+            Write-Host "Dry run: Would download from $PackageUrl to $PackagePath"
+            Write-Host "Dry run: Would extract from $PackagePath to $DataDstDir"
+        } else {
+            try {
+                Invoke-WebRequest -Uri $PackageUrl -OutFile $PackagePath
+            } catch {
+                Write-Error "Installation failed: There is no wasp version $VersionToInstall"
+                exit 1
+            }
+
+            Write-Host "Installing wasp data to $DataDstDir."
+            Expand-Archive -Path $PackagePath -DestinationPath $DataDstDir -Force
+            Remove-Item -Path $TempDir -Recurse -Force
+        }
+    } else {
+        Write-Host "Found an existing installation on the disk, at $DataDstDir. Using it instead."
+    }
+
+    $BinDstDir = $HomeLocalBin
+    New-Item -ItemType Directory -Force -Path $BinDstDir | Out-Null
+
+    if (Test-Path "$BinDstDir\wasp.cmd") {
+        Write-Host "Configuring wasp executable at $BinDstDir\wasp.cmd to use wasp version $VersionToInstall."
+    } else {
+        Write-Host "Installing wasp executable to $BinDstDir\wasp.cmd."
+    }
+
+    $WaspCmdContent = @"
+@echo off
+set "waspc_datadir=$DataDstDir\data"
+"$DataDstDir\wasp-bin.exe" %*
+"@
+    Set-Content -Path "$BinDstDir\wasp.cmd" -Value $WaspCmdContent
+
+    Write-Host "`n=============================================="
+
+    $UserPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
+    if (-not ($UserPath -split ';' -contains $BinDstDir)) {
+        Write-Host "$Red`nWARNING$Reset: It looks like '$BinDstDir' is not on your PATH! You will not be able to invoke wasp from the terminal by its name."
+        Write-Host "  You can add it to your PATH by running the following command in PowerShell and then restarting your terminal:"
+        Write-Host "      $Bold`[System.Environment]::SetEnvironmentVariable('Path', [System.Environment]::GetEnvironmentVariable('Path', 'User') + ';$BinDstDir', 'User')`$Reset"
+    }
+
+    Write-Host "$Green`nwasp has been successfully installed! To create your first app, do:$Reset"
+    if (-not ($UserPath -split ';' -contains $BinDstDir)) {
+        Write-Host " - Add wasp to your PATH as described above."
+    }
+    Write-Host " - $Bold`wasp new MyApp`$Reset"
+}
+
+Main

--- a/waspc/tools/make_binary_package.ps1
+++ b/waspc/tools/make_binary_package.ps1
@@ -1,0 +1,45 @@
+param (
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = "Stop"
+
+# The script is located in waspc/tools, so we need to go up one level to get to the waspc directory.
+$WaspC_Dir = (Get-Item $PSScriptRoot).Parent.FullName
+
+# Get the path to the built executable.
+$WaspC_Bin_Path = (cabal list-bin exe:wasp-cli)
+
+# The data directory.
+$Data_Dir = "$WaspC_Dir/data"
+
+# Other files to include.
+$Readme_Path = "$WaspC_Dir/README.md"
+$License_Path = "$WaspC_Dir/LICENSE"
+
+# Check if the files exist.
+if (-not (Test-Path $WaspC_Bin_Path)) {
+    Write-Error "wasp-cli.exe not found at $WaspC_Bin_Path"
+    exit 1
+}
+if (-not (Test-Path $Data_Dir)) {
+    Write-Error "data directory not found at $Data_Dir"
+    exit 1
+}
+
+# Create a temporary directory to stage the files.
+$Temp_Dir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "wasp-package")
+
+# Copy the files to the temporary directory.
+Copy-Item -Path $WaspC_Bin_Path -Destination (Join-Path $Temp_Dir "wasp-bin.exe")
+Copy-Item -Path $Data_Dir -Destination (Join-Path $Temp_Dir "data") -Recurse
+Copy-Item -Path $Readme_Path -Destination (Join-Path $Temp_Dir "README.md")
+Copy-Item -Path $License_Path -Destination (Join-Path $Temp_Dir "LICENSE")
+
+# Create the zip archive.
+Compress-Archive -Path $Temp_Dir\* -DestinationPath $OutputPath -Force
+
+# Clean up the temporary directory.
+Remove-Item -Path $Temp_Dir -Recurse -Force
+
+Write-Host "Successfully created package at $OutputPath"


### PR DESCRIPTION
This commit introduces initial support for Windows by:

- Modifying the GitHub Actions workflow to include a Windows build job.
- Adding a PowerShell script to package the Windows binary as a .zip file.
- Creating a PowerShell installer script (`installer.ps1`) for Windows, which mimics the functionality of the existing `installer.sh`.

The installer script supports versioning, downloads the appropriate release artifact from GitHub, installs it to your local app data directory, and provides instructions for adding the executable to the PATH.

Due to limitations in my current environment, I could not test the installer script. The changes will be verified when the GitHub Actions workflow is run.

### Description

> Describe your PR! If this PR closes an issue, use “Fixes #(issue_number)" syntax so GitHub will auto-close it when merged.

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change).
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed

If you did a **bug fix, new feature, or breaking change**, that affects `waspc`, make sure you satisfy the following:

1. [ ] I updated [`ChangeLog.md`](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped `waspc` version in [`waspc.cabal`](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.

### Add a regression test if needed

If you did a **bug fix**, make sure you satisfy the following:

1. [ ] I added a regression test that reproduces the bug and verifies the fix.

If you're unable to add a regression test, please explain why.
This likely indicates that our current testing setup needs improvement.

### Update example apps if needed

If you did code changes and **added a new feature**, make sure you satisfy the following:

1. [ ] I updated [`waspc/examples/todoApp`](https://github.com/wasp-lang/wasp/tree/main/waspc/examples/todoApp) and its e2e tests as needed and manually checked it works correctly.

If you did code changes and **updated an existing feature**, make sure you satisfy the following:

1. [ ] I updated [`waspc/examples/todoApp`](https://github.com/wasp-lang/wasp/tree/main/waspc/examples/todoApp) and its e2e tests as needed and manually checked it works correctly.

### Update starter apps if needed

If you did code changes and **updated an existing feature**, make sure you satisfy the following:

1. [ ] I updated [starter skeleton](https://github.com/wasp-lang/wasp/tree/main/waspc/data/Cli/templates/skeleton) as needed and manually checked it works correctly.
2. [ ] I updated [`basic` starter](https://github.com/wasp-lang/wasp/tree/main/waspc/data/Cli/templates/basic) as needed and manually checked it works correctly.
3. [ ] I updated [`todo-ts` starter](https://github.com/wasp-lang/starters/tree/dev/todo-ts) as needed and manually checked it works correctly.
4. [ ] I updated [`embeddings` starter](https://github.com/wasp-lang/starters/tree/dev/embeddings) as needed and manually checked it works correctly.
5. [ ] I updated [`saas` starter](https://github.com/wasp-lang/open-saas/tree/main/template) as needed and manually checked it works correctly.

### Update e2e tests if needed

If you did code changes and changed Wasp's code generation logic, make sure you satisfy the following:

1. [] I updated [e2e tests](https://github.com/wasp-lang/wasp/tree/main/waspc#end-to-end-e2e-tests) as needed and manually checked they are correct.
